### PR TITLE
use maven base image rather than open openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM openjdk:8-slim-stretch
-RUN apt-get update && apt-get upgrade -y && apt-get -y install git maven 
+FROM maven:3.6.1-jdk-8
 RUN git clone https://github.com/RUB-NDS/TLS-Attacker.git
 RUN git clone https://github.com/RUB-NDS/TLS-Scanner.git
 WORKDIR /TLS-Attacker/


### PR DESCRIPTION
For me, building the Docker image fails with:

```
Setting up openjdk-8-jre-headless:amd64 (8u222-b10-1~deb9u1) ...
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmid to provide /usr/bin/rmid (rmid) in auto mode
update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
dpkg: error processing package openjdk-8-jre-headless:amd64 (--configure):
 subprocess installed post-installation script returned error exit status 2
dpkg: dependency problems prevent configuration of default-jre-headless:
 default-jre-headless depends on openjdk-8-jre-headless; however:
  Package openjdk-8-jre-headless:amd64 is not configured yet.
```

But using apt-get to install Maven is unnecessary if we use the Maven
base image.  So switch from `openjdk:8-slim-stretch` to
`maven:3.6.1-jdk-8` instead.