### PR TITLE
Check out submodules in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM maven:3.6.1-jdk-8
 RUN git clone https://github.com/RUB-NDS/TLS-Attacker.git
-RUN git clone https://github.com/RUB-NDS/TLS-Scanner.git
+RUN git clone https://github.com/RUB-NDS/TLS-Scanner.git --recurse-submodules
 WORKDIR /TLS-Attacker/
 RUN mvn clean install -DskipTests=true
-RUN git clone https://github.com/RUB-NDS/TLS-Scanner.git
 WORKDIR /TLS-Scanner/
 RUN mvn clean install -DskipTests=true
 WORKDIR /TLS-Scanner/apps/


### PR DESCRIPTION
When using the Dockerfile to run the scanner, I was seeing an exception about an empty XML file. To fix this, I updated the Dockerfile to pass `--recurse-submodules` when cloning this repository inside the container. I also got rid of a duplicate clone in the Dockerfile, as it looked unused.